### PR TITLE
Add TUI library and integrate with server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # Promptbox
 
-Promptbox manages text prompts with a CLI and web interface powered by Bun.
+Promptbox manages text prompts with a TUI and web interface powered by Bun.
 
-## Commands
+## Usage
 
-- `bun run src/cli.ts add <name> <content>` - add a new prompt
-- `bun run src/cli.ts list` - list all prompts
-- `bun run src/cli.ts view <id>` - view a prompt by id
-- `bun run src/cli.ts update <id> <name> <content>` - update an existing prompt
-- `bun run src/cli.ts delete <id>` - delete a prompt
+- `bun run src/cli.ts` - start the interactive TUI
 - `bun run src/server.ts` - start the web server
 
 The web server exposes a small API under `/api/prompts` and serves a simple

--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,10 @@
   "workspaces": {
     "": {
       "name": "promptbox",
+      "dependencies": {
+        "neverthrow": "^8.2.0",
+        "ts-pattern": "^5.7.1",
+      },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/node": "^22.15.29",
@@ -13,11 +17,17 @@
     },
   },
   "packages": {
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.41.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A=="],
+
     "@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
 
     "@types/node": ["@types/node@22.15.29", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ=="],
 
     "bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
+
+    "neverthrow": ["neverthrow@8.2.0", "", { "optionalDependencies": { "@rollup/rollup-linux-x64-gnu": "^4.24.0" } }, "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ=="],
+
+    "ts-pattern": ["ts-pattern@5.7.1", "", {}, "sha512-EGs8PguQqAAUIcQfK4E9xdXxB6s2GK4sJfT/vcc9V1ELIvC4LH/zXu2t/5fajtv6oiRCxdv7BgtVK3vWgROxag=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 

--- a/index.html
+++ b/index.html
@@ -8,13 +8,51 @@
 </head>
 <body class="p-4 font-sans">
   <h1 class="text-2xl mb-4">Prompts</h1>
-  <ul id="list"></ul>
+  <form id="add" class="mb-4 space-y-2">
+    <input class="border p-1 w-full" placeholder="Name" id="name" />
+    <textarea class="border p-1 w-full" placeholder="Content" id="content"></textarea>
+    <button class="bg-blue-600 text-white px-2 py-1" type="submit">Add</button>
+  </form>
+  <ul id="list" class="space-y-1"></ul>
   <script type="module">
-    const res = await fetch('/api/prompts');
-    const prompts = await res.json();
-    document.getElementById('list').innerHTML = prompts
-      .map(p => `<li><a class="text-blue-600" href="/prompt/${p.id}">${p.name}</a></li>`)
-      .join('');
+    const list = document.getElementById('list');
+    const form = document.getElementById('add');
+
+    async function load() {
+      const res = await fetch('/api/prompts');
+      const prompts = await res.json();
+      list.innerHTML = prompts
+        .map(
+          p => `<li class="flex justify-between"><a class="text-blue-600" href="/prompt/${p.id}">${p.name}</a><button data-id="${p.id}" class="text-red-600 delete">Delete</button></li>`,
+        )
+        .join('');
+    }
+
+    list.addEventListener('click', async e => {
+      const target = e.target;
+      if (target instanceof HTMLElement && target.classList.contains('delete')) {
+        const id = target.dataset.id;
+        if (!id) return;
+        await fetch('/api/prompts/' + id, { method: 'DELETE' });
+        load();
+      }
+    });
+
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      const name = document.getElementById('name').value;
+      const content = document.getElementById('content').value;
+      await fetch('/api/prompts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, content }),
+      });
+      (document.getElementById('name').value = ''),
+        (document.getElementById('content').value = '');
+      load();
+    });
+
+    load();
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
   },
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "dependencies": {
+    "neverthrow": "^8.2.0",
+    "ts-pattern": "^5.7.1"
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,3 @@
+export type PromptError =
+  | { readonly type: 'not-found'; readonly id: string }
+  | { readonly type: 'invalid-input'; readonly reason: string };

--- a/src/prompts.test.ts
+++ b/src/prompts.test.ts
@@ -26,7 +26,8 @@ afterEach(() => {
 
 describe('prompts', () => {
   it('adds and lists prompts', () => {
-    addPrompt('test', 'content');
+    const result = addPrompt('test', 'content');
+    expect(result.isOk()).toBe(true);
     const prompts = listPrompts();
     expect(prompts.length).toBe(1);
     const first = prompts[0];
@@ -37,24 +38,24 @@ describe('prompts', () => {
   });
 
   it('gets a prompt by id', () => {
-    const prompt = addPrompt('name', 'body');
-    const loaded = getPrompt(prompt.id);
-    expect(loaded?.content).toBe('body');
+    const prompt = addPrompt('name', 'body')._unsafeUnwrap();
+    const loaded = getPrompt(prompt.id)._unsafeUnwrap();
+    expect(loaded.content).toBe('body');
   });
 
   it('updates a prompt', () => {
-    const prompt = addPrompt('old', 'content');
-    const updated = updatePrompt(prompt.id, 'new', 'updated');
-    expect(updated?.name).toBe('new');
-    const loaded = getPrompt(prompt.id);
-    expect(loaded?.content).toBe('updated');
+    const prompt = addPrompt('old', 'content')._unsafeUnwrap();
+    const updated = updatePrompt(prompt.id, 'new', 'updated')._unsafeUnwrap();
+    expect(updated.name).toBe('new');
+    const loaded = getPrompt(prompt.id)._unsafeUnwrap();
+    expect(loaded.content).toBe('updated');
   });
 
   it('deletes a prompt', () => {
-    const prompt = addPrompt('temp', 'delete');
+    const prompt = addPrompt('temp', 'delete')._unsafeUnwrap();
     const result = deletePrompt(prompt.id);
-    expect(result).toBe(true);
-    expect(getPrompt(prompt.id)).toBeNull();
+    expect(result.isOk()).toBe(true);
+    expect(getPrompt(prompt.id).isErr()).toBe(true);
     expect(listPrompts().length).toBe(0);
   });
 });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,26 @@
+import { beforeAll, afterAll, describe, expect, it } from 'bun:test';
+import { createServer } from './server';
+
+let server: ReturnType<typeof createServer>;
+
+beforeAll(() => {
+  server = createServer();
+});
+
+afterAll(async () => {
+  await server.stop(true);
+});
+
+describe('server api', () => {
+  it('creates and lists prompts', async () => {
+    const res = await fetch(new URL('/api/prompts', server.url), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 't', content: 'c' }),
+    });
+    expect(res.status).toBe(201);
+    const listRes = await fetch(new URL('/api/prompts', server.url));
+    const prompts = await listRes.json();
+    expect(prompts.length).toBe(1);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import {
   listPrompts,
   updatePrompt,
 } from './prompts';
+import { match } from 'ts-pattern';
 
 const buildHtml = (body: string): string => `<!DOCTYPE html>
 <html lang="en">
@@ -18,54 +19,68 @@ const buildHtml = (body: string): string => `<!DOCTYPE html>
 <body class="p-4 font-sans">${body}</body>
 </html>`;
 
-const server = Bun.serve({
-  development: true,
-  routes: {
-    '/': indexPage,
-    '/prompt/:id': req => {
-      const prompt = getPrompt(req.params.id);
-      if (!prompt) {
-        return new Response('Not Found', { status: 404 });
-      }
-      const body = `<h1 class="text-2xl mb-4">${prompt.name}</h1><pre class="whitespace-pre-wrap">${prompt.content}</pre>`;
-      return new Response(buildHtml(body), { headers: { 'Content-Type': 'text/html' } });
-    },
-    '/api/prompts': {
-      GET: () => Response.json(listPrompts()),
-      POST: async req => {
-        const { name, content } = await req.json();
-        if (typeof name !== 'string' || typeof content !== 'string') {
-          return new Response('Invalid', { status: 400 });
-        }
-        const prompt = addPrompt(name, content);
-        return Response.json(prompt, { status: 201 });
+export const createServer = () =>
+  Bun.serve({
+    development: true,
+    routes: {
+      '/': indexPage,
+      '/prompt/:id': req => {
+        const result = getPrompt(req.params.id);
+        return result.match(
+          prompt => {
+            const body = `<h1 class="text-2xl mb-4">${prompt.name}</h1><pre class="whitespace-pre-wrap">${prompt.content}</pre>`;
+            return new Response(buildHtml(body), { headers: { 'Content-Type': 'text/html' } });
+          },
+          () => new Response('Not Found', { status: 404 }),
+        );
+      },
+      '/api/prompts': {
+        GET: () => Response.json(listPrompts()),
+        POST: async req => {
+          const { name, content } = await req.json();
+          if (typeof name !== 'string' || typeof content !== 'string') {
+            return new Response('Invalid', { status: 400 });
+          }
+          const result = addPrompt(name, content);
+          return result.match(
+            prompt => Response.json(prompt, { status: 201 }),
+            err =>
+              match(err)
+                .with({ type: 'invalid-input' }, e => new Response(e.reason, { status: 400 }))
+                .otherwise(() => new Response('Not Found', { status: 404 })),
+          );
+        },
+      },
+      '/api/prompts/:id': {
+        GET: req =>
+          getPrompt(req.params.id).match(
+            prompt => Response.json(prompt),
+            () => new Response('Not Found', { status: 404 }),
+          ),
+        PUT: async req => {
+          const { name, content } = await req.json();
+          if (typeof name !== 'string' || typeof content !== 'string') {
+            return new Response('Invalid', { status: 400 });
+          }
+          const result = updatePrompt(req.params.id, name, content);
+          return result.match(
+            prompt => Response.json(prompt),
+            error =>
+              match(error)
+                .with({ type: 'invalid-input' }, e => new Response(e.reason, { status: 400 }))
+                .otherwise(() => new Response('Not Found', { status: 404 })),
+          );
+        },
+        DELETE: req =>
+          deletePrompt(req.params.id).match(
+            () => new Response(null, { status: 204 }),
+            () => new Response('Not Found', { status: 404 }),
+          ),
       },
     },
-    '/api/prompts/:id': {
-      GET: req => {
-        const prompt = getPrompt(req.params.id);
-        if (!prompt) {
-          return new Response('Not Found', { status: 404 });
-        }
-        return Response.json(prompt);
-      },
-      PUT: async req => {
-        const { name, content } = await req.json();
-        if (typeof name !== 'string' || typeof content !== 'string') {
-          return new Response('Invalid', { status: 400 });
-        }
-        const updated = updatePrompt(req.params.id, name, content);
-        if (!updated) {
-          return new Response('Not Found', { status: 404 });
-        }
-        return Response.json(updated);
-      },
-      DELETE: req => {
-        const deleted = deletePrompt(req.params.id);
-        return deleted ? new Response(null, { status: 204 }) : new Response('Not Found', { status: 404 });
-      },
-    },
-  },
-});
+  });
 
-console.log(`Server running at ${server.url}`);
+if (import.meta.main) {
+  const server = createServer();
+  console.log(`Server running at ${server.url}`);
+}

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -1,0 +1,2 @@
+export { TuiMenu } from './menu';
+export { ask } from './input';

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -1,0 +1,23 @@
+import { createInterface } from 'readline';
+import { Writable, Readable } from 'stream';
+
+export type InputOptions = {
+  readonly input?: Readable;
+  readonly output?: Writable;
+};
+
+export const ask = async (
+  question: string,
+  options: InputOptions = {},
+): Promise<string> => {
+  const rl = createInterface({
+    input: options.input ?? process.stdin,
+    output: options.output ?? process.stdout,
+  });
+  return new Promise(resolve =>
+    rl.question(question, answer => {
+      rl.close();
+      resolve(answer);
+    }),
+  );
+};

--- a/src/tui/menu.test.ts
+++ b/src/tui/menu.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { PassThrough } from 'stream';
+import { TuiMenu } from './menu';
+
+const arrowDown = '\u001b[B';
+const enter = '\r';
+
+describe('TuiMenu', () => {
+  it('returns selected index', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const menu = new TuiMenu(['a', 'b', 'c'], { input, output });
+    const runPromise = menu.run();
+    input.write(arrowDown);
+    input.write(arrowDown);
+    input.write(enter);
+    const index = await runPromise;
+    expect(index).toBe(2);
+  });
+});

--- a/src/tui/menu.ts
+++ b/src/tui/menu.ts
@@ -1,0 +1,67 @@
+import { match } from 'ts-pattern';
+import { Writable, Readable } from 'stream';
+
+export type MenuOptions = {
+  readonly input?: Readable;
+  readonly output?: Writable;
+};
+
+export class TuiMenu {
+  private index = 0;
+  private readonly input: Readable;
+  private readonly output: Writable;
+  private readonly items: ReadonlyArray<string>;
+
+  constructor(items: ReadonlyArray<string>, options: MenuOptions = {}) {
+    this.items = items;
+    this.input = options.input ?? process.stdin;
+    this.output = options.output ?? process.stdout;
+  }
+
+  async run(): Promise<number> {
+    return new Promise<number>(resolve => {
+      const onData = (data: Buffer): void => {
+        const key = data.toString();
+        match(key)
+          .with('\u001b[A', () => this.move(-1)) // up
+          .with('\u001b[B', () => this.move(1)) // down
+          .with('\r', () => finish()) // enter
+          .otherwise(() => undefined);
+      };
+
+      const finish = (): void => {
+        this.cleanup(onData);
+        resolve(this.index);
+      };
+
+      if (typeof (this.input as NodeJS.ReadStream).setRawMode === 'function') {
+        (this.input as NodeJS.ReadStream).setRawMode(true);
+      }
+      this.input.resume();
+      this.input.on('data', onData);
+      this.render();
+    });
+  }
+
+  private cleanup(onData: (data: Buffer) => void): void {
+    this.input.removeListener('data', onData);
+    if (typeof (this.input as NodeJS.ReadStream).setRawMode === 'function') {
+      (this.input as NodeJS.ReadStream).setRawMode(false);
+    }
+    this.output.write('\n');
+  }
+
+  private move(delta: number): void {
+    const total = this.items.length;
+    this.index = (this.index + delta + total) % total;
+    this.render();
+  }
+
+  private render(): void {
+    this.output.write('\x1b[2J\x1b[0f'); // clear screen
+    this.items.forEach((item, i) => {
+      const prefix = i === this.index ? '> ' : '  ';
+      this.output.write(`${prefix}${item}\n`);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- replace CLI with interactive TUI
- create basic TUI library with menu and input helpers
- refactor prompt management to use neverthrow results
- rewrite server to use ts-pattern and result handling
- expand index.html with form and delete buttons
- add unit tests for TUI menu and server routes

## Testing
- `bun test`
- `bun run tsc -p .`


------
https://chatgpt.com/codex/tasks/task_e_683fc638463c832091e7f1d43d0bbfa7