### PR TITLE
Switch to sqlite storage

### DIFF
--- a/src/prompts.test.ts
+++ b/src/prompts.test.ts
@@ -5,22 +5,25 @@ import {
   getPrompt,
   listPrompts,
   updatePrompt,
+  closeDb,
 } from './prompts';
 import { existsSync, rmSync } from 'fs';
 import { join } from 'path';
 
 const DATA_DIR = join(process.cwd(), 'data');
-const PROMPTS_FILE = join(DATA_DIR, 'prompts.json');
+const DB_FILE = join(DATA_DIR, 'prompts.sqlite');
 
 beforeEach(() => {
-  if (existsSync(PROMPTS_FILE)) {
-    rmSync(PROMPTS_FILE);
+  closeDb();
+  if (existsSync(DB_FILE)) {
+    rmSync(DB_FILE);
   }
 });
 
 afterEach(() => {
-  if (existsSync(PROMPTS_FILE)) {
-    rmSync(PROMPTS_FILE);
+  closeDb();
+  if (existsSync(DB_FILE)) {
+    rmSync(DB_FILE);
   }
 });
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,14 +1,27 @@
 import { beforeAll, afterAll, describe, expect, it } from 'bun:test';
 import { createServer } from './server';
+import { existsSync, rmSync } from 'fs';
+import { closeDb } from './prompts';
+import { join } from 'path';
+
+const DB_FILE = join(process.cwd(), 'data', 'prompts.sqlite');
 
 let server: ReturnType<typeof createServer>;
 
 beforeAll(() => {
+  closeDb();
+  if (existsSync(DB_FILE)) {
+    rmSync(DB_FILE);
+  }
   server = createServer();
 });
 
 afterAll(async () => {
   await server.stop(true);
+  closeDb();
+  if (existsSync(DB_FILE)) {
+    rmSync(DB_FILE);
+  }
 });
 
 describe('server api', () => {


### PR DESCRIPTION
## Summary
- migrate JSON persistence to bun:sqlite database
- add closeDb utility for tests
- update unit tests to reset sqlite file

## Testing
- `bun test`
- `bun run tsc -p .`


------
https://chatgpt.com/codex/tasks/task_e_683fd7d22bc48320b19ab8b5d398a305