### PR TITLE
Improve routing utilities

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import { err, ok } from 'neverthrow';
+import { parseJson, validatePromptInput, toResponse, toEmptyResponse } from './router';
+import type { PromptError } from './errors';
+
+const readJson = async (body: string) =>
+  parseJson<Record<string, unknown>>(new Request('http://t', { method: 'POST', body }));
+
+describe('router utilities', () => {
+  it('parses valid json', async () => {
+    const result = await readJson('{"a":1}');
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('rejects invalid json', async () => {
+    const result = await readJson('no');
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status).toBe(400);
+    }
+  });
+
+  it('validates prompt input', () => {
+    const okResult = validatePromptInput({ name: 'n', content: 'c' });
+    expect(okResult.isOk()).toBe(true);
+    const errResult = validatePromptInput({ wrong: true });
+    expect(errResult.isErr()).toBe(true);
+  });
+
+  it('converts result to response', () => {
+    const success = toResponse(ok<Record<string, never>>({}), 201);
+    expect(success.status).toBe(201);
+    const failure = toResponse(err<void, PromptError>({ type: 'not-found', id: 'x' }));
+    expect(failure.status).toBe(404);
+  });
+
+  it('converts result to empty response', () => {
+    const success = toEmptyResponse(ok(undefined));
+    expect(success.status).toBe(204);
+    const failure = toEmptyResponse(err<void, PromptError>({ type: 'invalid-input', reason: 'bad' }));
+    expect(failure.status).toBe(400);
+  });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,52 @@
+import { match, P } from 'ts-pattern';
+import { Result, ok, err } from 'neverthrow';
+import type { PromptError } from './errors';
+
+export type PromptInput = {
+  readonly name: string;
+  readonly content: string;
+};
+
+export const parseJson = async <T>(req: Request): Promise<Result<T, Response>> => {
+  try {
+    const data = (await req.json()) as T;
+    return ok(data);
+  } catch {
+    return err(new Response('Invalid JSON', { status: 400 }));
+  }
+};
+
+export const validatePromptInput = (
+  data: Record<string, unknown>,
+): Result<PromptInput, Response> =>
+  match(data)
+    .with({ name: P.string, content: P.string }, ({ name, content }) =>
+      ok({ name, content }),
+    )
+    .otherwise(() => err(new Response('Invalid', { status: 400 })));
+
+export const toResponse = <T>(
+  result: Result<T, PromptError>,
+  status = 200,
+): Response =>
+  result.match(
+    value => Response.json(value, { status }),
+    error =>
+      match(error)
+        .with({ type: 'invalid-input' }, e => new Response(e.reason, { status: 400 }))
+        .with({ type: 'not-found' }, () => new Response('Not Found', { status: 404 }))
+        .exhaustive(),
+  );
+
+export const toEmptyResponse = (
+  result: Result<unknown, PromptError>,
+  status = 204,
+): Response =>
+  result.match(
+    () => new Response(null, { status }),
+    error =>
+      match(error)
+        .with({ type: 'invalid-input' }, e => new Response(e.reason, { status: 400 }))
+        .with({ type: 'not-found' }, () => new Response('Not Found', { status: 404 }))
+        .exhaustive(),
+  );

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -96,4 +96,31 @@ describe('server api', () => {
     );
     expect(getRes.status).toBe(404);
   });
+
+  it('rejects invalid json', async () => {
+    const res = await fetch(new URL('/api/prompts', server.url), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'no',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects missing fields', async () => {
+    const res = await fetch(new URL('/api/prompts', server.url), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'only' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for updating missing prompt', async () => {
+    const res = await fetch(new URL('/api/prompts/none', server.url), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'n', content: 'c' }),
+    });
+    expect(res.status).toBe(404);
+  });
 });


### PR DESCRIPTION
## Summary
- centralize API validation and error handling with new router utilities
- refactor server to use the new helpers
- enforce input validation and error paths in tests
- cover utilities with unit tests

## Testing
- `bun run tsc -p .`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683fe016e47c8320a6f7e20f3ffbd937