### PR TITLE
Add typed router abstraction

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -50,3 +50,124 @@ export const toEmptyResponse = (
         .with({ type: 'not-found' }, () => new Response('Not Found', { status: 404 }))
         .exhaustive(),
   );
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+type PathParams<P extends string> =
+  P extends `${string}:${infer Param}/${infer Rest}`
+    ? { [K in Param | keyof PathParams<Rest>]: string }
+    : P extends `${string}:${infer Param}`
+    ? { [K in Param]: string }
+    : {};
+
+type Validator<T> = (data: Record<string, unknown>) => Result<T, Response>;
+
+type Route<P extends string, B> = {
+  readonly method: HttpMethod;
+  readonly match: (url: URL) => PathParams<P> | null;
+  readonly handler: (
+    ctx: { readonly req: Request; readonly params: PathParams<P>; readonly body: B },
+  ) => Promise<Response> | Response;
+  readonly validate?: Validator<B>;
+};
+
+const buildMatcher = <P extends string>(path: P) => {
+  const parts = path.split('/').filter(Boolean);
+  return (url: URL): PathParams<P> | null => {
+    const urlParts = url.pathname.split('/').filter(Boolean);
+    if (urlParts.length !== parts.length) return null;
+    const params: Record<string, string> = {};
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]!;
+      const current = urlParts[i]!;
+      if (part.startsWith(':')) {
+        params[part.slice(1)] = decodeURIComponent(current);
+      } else if (part !== current) {
+        return null;
+      }
+    }
+    return params as PathParams<P>;
+  };
+};
+
+export class Router {
+  constructor(private readonly routes: readonly Route<string, unknown>[] = []) {}
+
+  private with(route: Route<string, unknown>): Router {
+    return new Router([...this.routes, route]);
+  }
+
+  add<P extends string, B>(
+    method: HttpMethod,
+    path: P,
+    handler: (
+      ctx: { readonly req: Request; readonly params: PathParams<P>; readonly body: B },
+    ) => Promise<Response> | Response,
+    validate?: Validator<B>,
+  ): Router {
+    return this.with({
+      method,
+      match: buildMatcher(path),
+      handler: handler as Route<string, unknown>['handler'],
+      validate: validate as Validator<unknown> | undefined,
+    });
+  }
+
+  get<P extends string>(
+    path: P,
+    handler: (
+      ctx: { readonly req: Request; readonly params: PathParams<P>; readonly body: undefined },
+    ) => Promise<Response> | Response,
+  ): Router {
+    return this.add('GET', path, handler);
+  }
+
+  post<P extends string, B>(
+    path: P,
+    validate: Validator<B>,
+    handler: (
+      ctx: { readonly req: Request; readonly params: PathParams<P>; readonly body: B },
+    ) => Promise<Response> | Response,
+  ): Router {
+    return this.add('POST', path, handler, validate);
+  }
+
+  put<P extends string, B>(
+    path: P,
+    validate: Validator<B>,
+    handler: (
+      ctx: { readonly req: Request; readonly params: PathParams<P>; readonly body: B },
+    ) => Promise<Response> | Response,
+  ): Router {
+    return this.add('PUT', path, handler, validate);
+  }
+
+  delete<P extends string>(
+    path: P,
+    handler: (
+      ctx: { readonly req: Request; readonly params: PathParams<P>; readonly body: undefined },
+    ) => Promise<Response> | Response,
+  ): Router {
+    return this.add('DELETE', path, handler);
+  }
+
+  async handle(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    for (const route of this.routes) {
+      if (route.method !== req.method) continue;
+      const params = route.match(url);
+      if (!params) continue;
+      let body: unknown = undefined;
+      if (route.validate) {
+        const json = await parseJson<Record<string, unknown>>(req);
+        if (json.isErr()) return json.error;
+        const validated = route.validate(json.value);
+        if (validated.isErr()) return validated.error;
+        body = validated.value;
+      }
+      return route.handler({ req, params, body } as never);
+    }
+    return new Response('Not Found', { status: 404 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement a `Router` class for typed route handling
- use new router in the server to simplify endpoint definitions
- expand router tests to cover routing and validation logic
- refactor Router to immutable design

## Testing
- `bun test`
- `bun run tsc -p .`


------
https://chatgpt.com/codex/tasks/task_e_683fe7c075a48320b964173c5573b7d4