### PR TITLE
Improve router with middleware support

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -97,6 +97,11 @@ describe('server api', () => {
     expect(getRes.status).toBe(404);
   });
 
+  it('adds middleware headers', async () => {
+    const res = await fetch(new URL('/api/prompts', server.url));
+    expect(res.headers.get('x-powered-by')).toBe('Promptbox');
+  });
+
   it('rejects invalid json', async () => {
     const res = await fetch(new URL('/api/prompts', server.url), {
       method: 'POST',

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,11 @@ const buildHtml = (body: string): string => `<!DOCTYPE html>
 
 export const createServer = () => {
   const router = new Router()
+    .use(async (req, next) => {
+      const res = await next();
+      res.headers.set('X-Powered-By', 'Promptbox');
+      return res;
+    })
     .get('/api/prompts', () => Response.json(listPrompts()))
     .post('/api/prompts', validatePromptInput, ({ body }) =>
       toResponse(addPrompt(body.name, body.content), 201),


### PR DESCRIPTION
## Summary
- enhance `Router` with middleware chaining
- add a powered-by header middleware in the server
- expose router middleware test
- test that server sends middleware headers
- refactor router json handling

## Testing
- `bun run test`
- `tsc -p . --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683fee4de494832085687155eddee377