### PR TITLE
Improve db layer with explicit error handling

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,74 @@
+import { Database, type Changes, type SQLQueryBindings } from 'bun:sqlite';
+import { ok, err, type Result } from 'neverthrow';
+
+export type DbError =
+  | { readonly type: 'connection-failed'; readonly reason: string }
+  | { readonly type: 'query-failed'; readonly reason: string }
+  | { readonly type: 'constraint-violation'; readonly reason: string };
+
+export type DbConnection = {
+  readonly all: <T>(
+    query: string,
+    params: ReadonlyArray<SQLQueryBindings>
+  ) => Result<readonly T[], DbError>;
+  readonly run: (
+    query: string,
+    params: ReadonlyArray<SQLQueryBindings>
+  ) => Result<Changes, DbError>;
+  readonly close: () => void;
+};
+
+export const createConnection = (
+  dbPath: string,
+): Result<DbConnection, DbError> => {
+  try {
+    const db = new Database(dbPath);
+    db.exec('PRAGMA journal_mode = WAL;');
+
+    const all = <T>(query: string, params: ReadonlyArray<SQLQueryBindings>) => {
+      try {
+        const stmt = db.prepare(query);
+        return ok(stmt.all(...params) as readonly T[]);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes('UNIQUE constraint')
+        ) {
+          const e: DbError = { type: 'constraint-violation', reason: error.message };
+          return err(e);
+        }
+        const e: DbError = { type: 'query-failed', reason: String(error) };
+        return err(e);
+      }
+    };
+
+    const run = (
+      query: string,
+      params: ReadonlyArray<SQLQueryBindings>,
+    ): Result<Changes, DbError> => {
+      try {
+        const stmt = db.prepare(query);
+        return ok(stmt.run(...params));
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes('UNIQUE constraint')
+        ) {
+          const e: DbError = { type: 'constraint-violation', reason: error.message };
+          return err(e);
+        }
+        const e: DbError = { type: 'query-failed', reason: String(error) };
+        return err(e);
+      }
+    };
+
+    const connection: DbConnection = {
+      all,
+      run,
+      close: () => db.close(false),
+    };
+    return ok(connection);
+  } catch (error) {
+    return err({ type: 'connection-failed', reason: String(error) });
+  }
+};

--- a/src/prompt-repo.ts
+++ b/src/prompt-repo.ts
@@ -1,0 +1,86 @@
+import { err, ok, type Result } from 'neverthrow';
+import type { DbConnection, DbError } from './db';
+import type { Prompt } from './types';
+import type { PromptError } from './errors';
+
+export const createPromptRepo = (db: DbConnection) => {
+  const mapDbError = (error: DbError): PromptError => ({
+    type: 'invalid-input',
+    reason: error.reason,
+  });
+
+  const addPrompt = (
+    id: string,
+    name: string,
+    content: string,
+  ): Result<Prompt, PromptError> =>
+    db
+      .run('INSERT INTO prompts (id, name, content) VALUES (?1, ?2, ?3)', [
+        id,
+        name,
+        content,
+      ])
+      .map((): Prompt => ({ id, name, content }))
+      .mapErr(mapDbError);
+
+  const getPrompt = (id: string): Result<Prompt, PromptError> =>
+    db
+      .all<Prompt>(
+        'SELECT id, name, content FROM prompts WHERE id = ?1',
+        [id],
+      )
+      .mapErr(mapDbError)
+      .andThen((rows) => {
+        const [first] = rows;
+        if (first) {
+          return ok(first);
+        }
+        const notFound: PromptError = { type: 'not-found', id };
+        return err(notFound);
+      });
+
+  const listPrompts = (): Result<ReadonlyArray<Prompt>, PromptError> =>
+    db.all<Prompt>('SELECT id, name, content FROM prompts', [])
+      .map((rows) => rows as ReadonlyArray<Prompt>)
+      .mapErr(mapDbError);
+
+  const updatePrompt = (
+    id: string,
+    name: string,
+    content: string,
+  ): Result<Prompt, PromptError> =>
+    db
+      .run('UPDATE prompts SET name = ?1, content = ?2 WHERE id = ?3', [
+        name,
+        content,
+        id,
+      ])
+      .mapErr(mapDbError)
+      .andThen((result) => {
+        if (result.changes === 0) {
+          const notFound: PromptError = { type: 'not-found', id };
+          return err(notFound);
+        }
+        return ok({ id, name, content });
+      });
+
+  const deletePrompt = (id: string): Result<void, PromptError> =>
+    db
+      .run('DELETE FROM prompts WHERE id = ?1', [id])
+      .mapErr(mapDbError)
+      .andThen((result) => {
+        if (result.changes === 0) {
+          const notFound: PromptError = { type: 'not-found', id };
+          return err(notFound);
+        }
+        return ok(undefined);
+      });
+
+  return {
+    addPrompt,
+    getPrompt,
+    listPrompts,
+    updatePrompt,
+    deletePrompt,
+  } as const;
+};


### PR DESCRIPTION
## Summary
- create `db` module to wrap Bun SQLite with Result-based API
- refactor prompt store to use the new `db` wrapper
- extract `prompt-repo` for database access logic

## Testing
- `bun run typecheck`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68405cb2c820832080e6d812bbdf910d