### PR TITLE
Replace neverthrow with Effect

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@effect/platform-bun": "^0.69.2",
         "@effect/schema": "^0.75.5",
         "effect": "^3.16.3",
-        "neverthrow": "^8.2.0",
         "ts-pattern": "^5.7.1",
       },
       "devDependencies": {
@@ -104,8 +103,6 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
 
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.41.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A=="],
-
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
@@ -139,8 +136,6 @@
     "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
 
     "multipasta": ["multipasta@0.2.5", "", {}, "sha512-c8eMDb1WwZcE02WVjHoOmUVk7fnKU/RmUcosHACglrWAuPQsEJv+E8430sXj6jNc1jHw0zrS16aCjQh4BcEb4A=="],
-
-    "neverthrow": ["neverthrow@8.2.0", "", { "optionalDependencies": { "@rollup/rollup-linux-x64-gnu": "^4.24.0" } }, "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@effect/platform-bun": "^0.69.2",
     "@effect/schema": "^0.75.5",
     "effect": "^3.16.3",
-    "neverthrow": "^8.2.0",
     "ts-pattern": "^5.7.1"
   },
   "trustedDependencies": ["@biomejs/biome", "@parcel/watcher"]

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,6 +4,7 @@ import { existsSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import process from "node:process"
 import { PassThrough } from "node:stream"
+import { Effect } from "effect"
 import { ask } from "./input.ts"
 import { TuiMenu } from "./menu.ts"
 import { createPromptStore } from "./prompts.ts"
@@ -53,7 +54,7 @@ describe("cli tui", () => {
     const contentPromise = ask("Content: ", { input, output })
     input.write("body\n")
     const content = await contentPromise
-    addPrompt(name, content)
+    Effect.runSync(addPrompt(name, content))
 
     const prompts = listPrompts()
     if (prompts.length === 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import console from "node:console"
+import { Cause, Effect, Exit, Option } from "effect"
 import { match } from "ts-pattern"
 import { createPromptStore } from "./prompts.ts"
 
@@ -23,49 +24,75 @@ const handleList = (): void => {
 
 const handleView = async (): Promise<void> => {
   const id = await ask("Prompt id: ")
-  const result = getPrompt(id)
-  result.match(
-    (prompt) => {
+  const exit = Effect.runSyncExit(getPrompt(id))
+  Exit.match(exit, {
+    onSuccess: (prompt): void => {
       console.log(`Name: ${prompt.name}\nContent: ${prompt.content}`)
     },
-    (error) => console.log(`Error: ${error.type}`)
-  )
+    onFailure: (cause): void => {
+      const option = Cause.failureOption(cause)
+      if (Option.isSome(option)) {
+        console.log(`Error: ${option.value.type}`)
+      } else {
+        console.log("Error")
+      }
+    }
+  })
 }
 
 const handleAdd = async (): Promise<void> => {
   const name = await ask("Name: ")
   const content = await ask("Content: ")
-  const result = addPrompt(name, content)
-  result.match(
-    (prompt) => console.log(`Added prompt ${prompt.id}`),
-    (err) =>
-      match(err)
-        .with({ type: "invalid-input" }, (e) => console.log(`Error: ${e.reason}`))
-        .otherwise((e) => console.log(`Error: ${e.type}`))
-  )
+  const exit = Effect.runSyncExit(addPrompt(name, content))
+  Exit.match(exit, {
+    onSuccess: (prompt): void => console.log(`Added prompt ${prompt.id}`),
+    onFailure: (cause): void => {
+      const option = Cause.failureOption(cause)
+      if (Option.isSome(option)) {
+        match(option.value)
+          .with({ type: "invalid-input" }, (e) => console.log(`Error: ${e.reason}`))
+          .otherwise((e) => console.log(`Error: ${e.type}`))
+      } else {
+        console.log("Error")
+      }
+    }
+  })
 }
 
 const handleUpdate = async (): Promise<void> => {
   const id = await ask("Id: ")
   const name = await ask("Name: ")
   const content = await ask("Content: ")
-  const result = updatePrompt(id, name, content)
-  result.match(
-    (prompt) => console.log(`Updated ${prompt.id}`),
-    (err) =>
-      match(err)
-        .with({ type: "invalid-input" }, (e) => console.log(`Error: ${e.reason}`))
-        .otherwise((e) => console.log(`Error: ${e.type}`))
-  )
+  const exit = Effect.runSyncExit(updatePrompt(id, name, content))
+  Exit.match(exit, {
+    onSuccess: (prompt): void => console.log(`Updated ${prompt.id}`),
+    onFailure: (cause): void => {
+      const option = Cause.failureOption(cause)
+      if (Option.isSome(option)) {
+        match(option.value)
+          .with({ type: "invalid-input" }, (e) => console.log(`Error: ${e.reason}`))
+          .otherwise((e) => console.log(`Error: ${e.type}`))
+      } else {
+        console.log("Error")
+      }
+    }
+  })
 }
 
 const handleDelete = async (): Promise<void> => {
   const id = await ask("Id: ")
-  const result = deletePrompt(id)
-  result.match(
-    () => console.log("Deleted"),
-    (err) => console.log(`Error: ${err.type}`)
-  )
+  const exit = Effect.runSyncExit(deletePrompt(id))
+  Exit.match(exit, {
+    onSuccess: (): void => console.log("Deleted"),
+    onFailure: (cause): void => {
+      const option = Cause.failureOption(cause)
+      if (Option.isSome(option)) {
+        console.log(`Error: ${option.value.type}`)
+      } else {
+        console.log("Error")
+      }
+    }
+  })
 }
 
 const main = async (): Promise<void> => {

--- a/src/prompt-repo.ts
+++ b/src/prompt-repo.ts
@@ -1,4 +1,4 @@
-import { type Result, err, ok } from "neverthrow"
+import { Effect, pipe } from "effect"
 import type { DbConnection, DbError } from "./db.ts"
 import type { PromptError } from "./errors.ts"
 import type { Prompt } from "./types.ts"
@@ -6,65 +6,70 @@ import type { Prompt } from "./types.ts"
 export const createPromptRepo = (
   db: DbConnection
 ): {
-  readonly addPrompt: (id: string, name: string, content: string) => Result<Prompt, PromptError>
-  readonly getPrompt: (id: string) => Result<Prompt, PromptError>
-  readonly listPrompts: () => Result<readonly Prompt[], PromptError>
-  readonly updatePrompt: (id: string, name: string, content: string) => Result<Prompt, PromptError>
-  readonly deletePrompt: (id: string) => Result<void, PromptError>
+  readonly addPrompt: (id: string, name: string, content: string) => Effect.Effect<Prompt, PromptError>
+  readonly getPrompt: (id: string) => Effect.Effect<Prompt, PromptError>
+  readonly listPrompts: () => Effect.Effect<readonly Prompt[], PromptError>
+  readonly updatePrompt: (id: string, name: string, content: string) => Effect.Effect<Prompt, PromptError>
+  readonly deletePrompt: (id: string) => Effect.Effect<void, PromptError>
 } => {
   const mapDbError = (error: DbError): PromptError => ({
     type: "invalid-input",
     reason: error.reason
   })
 
-  const addPrompt = (id: string, name: string, content: string): Result<Prompt, PromptError> =>
-    db
-      .run("INSERT INTO prompts (id, name, content) VALUES (?1, ?2, ?3)", [id, name, content])
-      .map((): Prompt => ({ id, name, content }))
-      .mapErr(mapDbError)
+  const addPrompt = (id: string, name: string, content: string): Effect.Effect<Prompt, PromptError> =>
+    pipe(
+      db.run("INSERT INTO prompts (id, name, content) VALUES (?1, ?2, ?3)", [id, name, content]),
+      Effect.map((): Prompt => ({ id, name, content })),
+      Effect.mapError(mapDbError)
+    )
 
-  const getPrompt = (id: string): Result<Prompt, PromptError> =>
-    db
-      .all<Prompt>("SELECT id, name, content FROM prompts WHERE id = ?1", [id])
-      .mapErr(mapDbError)
-      .andThen((rows) => {
+  const getPrompt = (id: string): Effect.Effect<Prompt, PromptError> =>
+    pipe(
+      db.all<Prompt>("SELECT id, name, content FROM prompts WHERE id = ?1", [id]),
+      Effect.mapError(mapDbError),
+      Effect.flatMap((rows) => {
         const [first] = rows
         if (first) {
-          return ok(first)
+          return Effect.succeed(first)
         }
         const notFound: PromptError = { type: "not-found", id }
-        return err(notFound)
+        return Effect.fail(notFound)
       })
+    )
 
-  const listPrompts = (): Result<readonly Prompt[], PromptError> =>
-    db
-      .all<Prompt>("SELECT id, name, content FROM prompts", [])
-      .map((rows) => rows as readonly Prompt[])
-      .mapErr(mapDbError)
+  const listPrompts = (): Effect.Effect<readonly Prompt[], PromptError> =>
+    pipe(
+      db.all<Prompt>("SELECT id, name, content FROM prompts", []),
+      Effect.map((rows) => rows as readonly Prompt[]),
+      Effect.mapError(mapDbError)
+    )
 
-  const updatePrompt = (id: string, name: string, content: string): Result<Prompt, PromptError> =>
-    db
-      .run("UPDATE prompts SET name = ?1, content = ?2 WHERE id = ?3", [name, content, id])
-      .mapErr(mapDbError)
-      .andThen((result) => {
+  const updatePrompt = (id: string, name: string, content: string): Effect.Effect<Prompt, PromptError> =>
+    pipe(
+      db.run("UPDATE prompts SET name = ?1, content = ?2 WHERE id = ?3", [name, content, id]),
+      Effect.mapError(mapDbError),
+      Effect.flatMap((result) => {
         if (result.changes === 0) {
           const notFound: PromptError = { type: "not-found", id }
-          return err(notFound)
+          return Effect.fail(notFound)
         }
-        return ok({ id, name, content })
+        return Effect.succeed({ id, name, content })
       })
+    )
 
-  const deletePrompt = (id: string): Result<void, PromptError> =>
-    db
-      .run("DELETE FROM prompts WHERE id = ?1", [id])
-      .mapErr(mapDbError)
-      .andThen((result) => {
+  const deletePrompt = (id: string): Effect.Effect<void, PromptError> =>
+    pipe(
+      db.run("DELETE FROM prompts WHERE id = ?1", [id]),
+      Effect.mapError(mapDbError),
+      Effect.flatMap((result) => {
         if (result.changes === 0) {
           const notFound: PromptError = { type: "not-found", id }
-          return err(notFound)
+          return Effect.fail(notFound)
         }
-        return ok(undefined)
+        return Effect.succeed(undefined)
       })
+    )
 
   return {
     addPrompt,

--- a/src/prompts-env.test.ts
+++ b/src/prompts-env.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { existsSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import process from "node:process"
+import { Effect } from "effect"
 import { createPromptStore } from "./prompts.ts"
 
 const CUSTOM_DIR = join(process.cwd(), "custom-data")
@@ -25,7 +26,7 @@ afterEach(() => {
 describe("PROMPTBOX_DATA_DIR", () => {
   it("stores database in the configured directory", () => {
     const { addPrompt, closeDb } = createPromptStore(CUSTOM_DIR)
-    addPrompt("env-test", "content")
+    Effect.runSync(addPrompt("env-test", "content"))
     closeDb()
     expect(existsSync(DB_PATH)).toBe(true)
   })

--- a/src/prompts.test.ts
+++ b/src/prompts.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { Effect, Exit } from "effect"
 import { createPromptStore } from "./prompts.ts"
 
 const { addPrompt, deletePrompt, getPrompt, listPrompts, updatePrompt, closeDb } = createPromptStore()
@@ -25,8 +26,8 @@ afterEach(() => {
 
 describe("prompts", () => {
   it("adds and lists prompts", () => {
-    const result = addPrompt("test", "content")
-    expect(result.isOk()).toBe(true)
+    const exit = Effect.runSyncExit(addPrompt("test", "content"))
+    expect(Exit.isSuccess(exit)).toBe(true)
     const prompts = listPrompts()
     expect(prompts.length).toBe(1)
     const first = prompts[0]
@@ -37,24 +38,25 @@ describe("prompts", () => {
   })
 
   it("gets a prompt by id", () => {
-    const prompt = addPrompt("name", "body")._unsafeUnwrap()
-    const loaded = getPrompt(prompt.id)._unsafeUnwrap()
+    const prompt = Effect.runSync(addPrompt("name", "body"))
+    const loaded = Effect.runSync(getPrompt(prompt.id))
     expect(loaded.content).toBe("body")
   })
 
   it("updates a prompt", () => {
-    const prompt = addPrompt("old", "content")._unsafeUnwrap()
-    const updated = updatePrompt(prompt.id, "new", "updated")._unsafeUnwrap()
+    const prompt = Effect.runSync(addPrompt("old", "content"))
+    const updated = Effect.runSync(updatePrompt(prompt.id, "new", "updated"))
     expect(updated.name).toBe("new")
-    const loaded = getPrompt(prompt.id)._unsafeUnwrap()
+    const loaded = Effect.runSync(getPrompt(prompt.id))
     expect(loaded.content).toBe("updated")
   })
 
   it("deletes a prompt", () => {
-    const prompt = addPrompt("temp", "delete")._unsafeUnwrap()
-    const result = deletePrompt(prompt.id)
-    expect(result.isOk()).toBe(true)
-    expect(getPrompt(prompt.id).isErr()).toBe(true)
+    const prompt = Effect.runSync(addPrompt("temp", "delete"))
+    const exit = Effect.runSyncExit(deletePrompt(prompt.id))
+    expect(Exit.isSuccess(exit)).toBe(true)
+    const getExit = Effect.runSyncExit(getPrompt(prompt.id))
+    expect(Exit.isFailure(getExit)).toBe(true)
     expect(listPrompts().length).toBe(0)
   })
 })

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from "node:fs"
 import { join } from "node:path"
 import process from "node:process"
-import { type Result, err, ok } from "neverthrow"
+import { Effect, Exit, pipe } from "effect"
 import { type DbConnection, type DbError, createConnection } from "./db.ts"
 import type { PromptError } from "./errors.ts"
 import { createPromptRepo } from "./prompt-repo.ts"
@@ -10,11 +10,11 @@ import type { Prompt } from "./types.ts"
 export const createPromptStore = (
   dataDir?: string
 ): {
-  readonly addPrompt: (name: string, content: string) => Result<Prompt, PromptError>
-  readonly getPrompt: (id: string) => Result<Prompt, PromptError>
+  readonly addPrompt: (name: string, content: string) => Effect.Effect<Prompt, PromptError>
+  readonly getPrompt: (id: string) => Effect.Effect<Prompt, PromptError>
   readonly listPrompts: () => readonly Prompt[]
-  readonly updatePrompt: (id: string, name: string, content: string) => Result<Prompt, PromptError>
-  readonly deletePrompt: (id: string) => Result<void, PromptError>
+  readonly updatePrompt: (id: string, name: string, content: string) => Effect.Effect<Prompt, PromptError>
+  readonly deletePrompt: (id: string) => Effect.Effect<void, PromptError>
   readonly closeDb: () => void
 } => {
   const { PROMPTBOX_DATA_DIR } = process.env
@@ -23,22 +23,27 @@ export const createPromptStore = (
   let db: DbConnection | undefined
   let repo: ReturnType<typeof createPromptRepo> | undefined
 
-  const getDb = (): Result<DbConnection, DbError> => {
+  const getDb = (): Effect.Effect<DbConnection, DbError> => {
     if (db) {
-      return ok(db)
+      return Effect.succeed(db)
     }
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true })
     }
-    return createConnection(dbFile).map((conn) => {
-      db = conn
-      conn.run(
-        "CREATE TABLE IF NOT EXISTS prompts (id TEXT PRIMARY KEY, name TEXT NOT NULL, content TEXT NOT NULL);",
-        []
-      )
-      repo = createPromptRepo(conn)
-      return conn
-    })
+    return pipe(
+      createConnection(dbFile),
+      Effect.map((conn) => {
+        db = conn
+        Effect.runSync(
+          conn.run(
+            "CREATE TABLE IF NOT EXISTS prompts (id TEXT PRIMARY KEY, name TEXT NOT NULL, content TEXT NOT NULL);",
+            []
+          )
+        )
+        repo = createPromptRepo(conn)
+        return conn
+      })
+    )
   }
 
   const closeDb = (): void => {
@@ -49,22 +54,25 @@ export const createPromptStore = (
     }
   }
 
-  const getRepo = (): Result<ReturnType<typeof createPromptRepo>, DbError> =>
-    getDb().map((conn) => {
-      if (!repo) {
-        repo = createPromptRepo(conn)
-      }
-      return repo
-    })
+  const getRepo = (): Effect.Effect<ReturnType<typeof createPromptRepo>, DbError> =>
+    pipe(
+      getDb(),
+      Effect.map((conn) => {
+        if (!repo) {
+          repo = createPromptRepo(conn)
+        }
+        return repo
+      })
+    )
 
   const mapDbError = (error: DbError): PromptError => ({
     type: "invalid-input",
     reason: error.reason
   })
 
-  const addPrompt = (name: string, content: string): Result<Prompt, PromptError> => {
+  const addPrompt = (name: string, content: string): Effect.Effect<Prompt, PromptError> => {
     if (!(name.trim() && content.trim())) {
-      return err({
+      return Effect.fail({
         type: "invalid-input",
         reason: "Empty values are not allowed"
       })
@@ -73,40 +81,53 @@ export const createPromptStore = (
       typeof crypto !== "undefined" && "randomUUID" in crypto
         ? crypto.randomUUID()
         : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
-    return getRepo()
-      .mapErr(mapDbError)
-      .andThen((r) => r.addPrompt(id, name, content))
+    return pipe(
+      getRepo(),
+      Effect.mapError(mapDbError),
+      Effect.flatMap((r) => r.addPrompt(id, name, content))
+    )
   }
 
-  const getPrompt = (id: string): Result<Prompt, PromptError> =>
-    getRepo()
-      .mapErr(mapDbError)
-      .andThen((r) => r.getPrompt(id))
+  const getPrompt = (id: string): Effect.Effect<Prompt, PromptError> =>
+    pipe(
+      getRepo(),
+      Effect.mapError(mapDbError),
+      Effect.flatMap((r) => r.getPrompt(id))
+    )
 
-  const listPrompts = (): readonly Prompt[] =>
-    getRepo()
-      .andThen((r) => r.listPrompts())
-      .match(
-        (rows) => rows,
-        () => []
+  const listPrompts = (): readonly Prompt[] => {
+    const exit = Effect.runSyncExit(
+      pipe(
+        getRepo(),
+        Effect.flatMap((r) => r.listPrompts())
       )
+    )
+    return Exit.match(exit, {
+      onSuccess: (rows): readonly Prompt[] => rows,
+      onFailure: (): readonly Prompt[] => []
+    })
+  }
 
-  const updatePrompt = (id: string, name: string, content: string): Result<Prompt, PromptError> => {
+  const updatePrompt = (id: string, name: string, content: string): Effect.Effect<Prompt, PromptError> => {
     if (!(name.trim() && content.trim())) {
-      return err({
+      return Effect.fail({
         type: "invalid-input",
         reason: "Empty values are not allowed"
       })
     }
-    return getRepo()
-      .mapErr(mapDbError)
-      .andThen((r) => r.updatePrompt(id, name, content))
+    return pipe(
+      getRepo(),
+      Effect.mapError(mapDbError),
+      Effect.flatMap((r) => r.updatePrompt(id, name, content))
+    )
   }
 
-  const deletePrompt = (id: string): Result<void, PromptError> =>
-    getRepo()
-      .mapErr(mapDbError)
-      .andThen((r) => r.deletePrompt(id))
+  const deletePrompt = (id: string): Effect.Effect<void, PromptError> =>
+    pipe(
+      getRepo(),
+      Effect.mapError(mapDbError),
+      Effect.flatMap((r) => r.deletePrompt(id))
+    )
 
   return {
     addPrompt,

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -1,43 +1,55 @@
 import { describe, expect, it } from "bun:test"
-import { type Result, err, ok } from "neverthrow"
+import { Cause, Effect, Exit, Either } from "effect"
 import type { PromptError } from "./errors.ts"
-import { type JsonValue, Router, parseJson, toEmptyResponse, toResponse, validatePromptInput } from "./router.ts"
+import {
+  type JsonObject,
+  type JsonValue,
+  Router,
+  parseJson,
+  toEmptyResponse,
+  toResponse,
+  validatePromptInput
+} from "./router.ts"
 
-const readJson = async (body: string): Promise<Result<JsonValue, Response>> =>
+const readJson = (body: string): Effect.Effect<JsonValue, Response> =>
   parseJson(new Request("http://t", { method: "POST", body }))
 
 describe("router utilities", () => {
   it("parses valid json", async () => {
-    const result = await readJson('{"a":1}')
-    expect(result.isOk()).toBe(true)
+    const exit = await Effect.runPromiseExit(readJson('{"a":1}'))
+    expect(Exit.isSuccess(exit)).toBe(true)
   })
 
   it("rejects invalid json", async () => {
-    const result = await readJson("no")
-    expect(result.isErr()).toBe(true)
-    if (result.isErr()) {
-      expect(result.error.status).toBe(400)
+    const exit = await Effect.runPromiseExit(readJson("no"))
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const either = Cause.failureOrCause(exit.cause)
+      if (Either.isLeft(either)) {
+        expect(either.left.status).toBe(400)
+      }
     }
   })
 
   it("validates prompt input", () => {
-    const okResult = validatePromptInput({ name: "n", content: "c" })
-    expect(okResult.isOk()).toBe(true)
-    const errResult = validatePromptInput({ wrong: true })
-    expect(errResult.isErr()).toBe(true)
+    const okExit = Effect.runSyncExit(validatePromptInput({ name: "n", content: "c" }))
+    expect(Exit.isSuccess(okExit)).toBe(true)
+    const badInput = { wrong: true } as unknown as JsonObject
+    const errExit = Effect.runSyncExit(validatePromptInput(badInput))
+    expect(Exit.isFailure(errExit)).toBe(true)
   })
 
   it("converts result to response", () => {
-    const success = toResponse(ok<Record<string, never>>({}), 201)
+    const success = toResponse(Effect.succeed<Record<string, never>>({}), 201)
     expect(success.status).toBe(201)
-    const failure = toResponse(err<void, PromptError>({ type: "not-found", id: "x" }))
+    const failure = toResponse(Effect.fail<PromptError>({ type: "not-found", id: "x" }))
     expect(failure.status).toBe(404)
   })
 
   it("converts result to empty response", () => {
-    const success = toEmptyResponse(ok(undefined))
+    const success = toEmptyResponse(Effect.succeed(undefined))
     expect(success.status).toBe(204)
-    const failure = toEmptyResponse(err<void, PromptError>({ type: "invalid-input", reason: "bad" }))
+    const failure = toEmptyResponse(Effect.fail<PromptError>({ type: "invalid-input", reason: "bad" }))
     expect(failure.status).toBe(400)
   })
 })


### PR DESCRIPTION
## Summary
- remove neverthrow dependency
- migrate database and repo helpers to use Effect
- update prompt store implementation for Effect
- refactor router utilities to rely on Effect
- update CLI and tests for Effect-based APIs

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6840abff1b2c8320a9242d347d59e7aa